### PR TITLE
fix Travis CI builds

### DIFF
--- a/lib/mobject.js
+++ b/lib/mobject.js
@@ -103,12 +103,17 @@ MObject.prototype.delProp = function(prop, callback) {
 
   var upd = {$unset: {}};
   upd.$unset[prop] = '';
+  
+  this._app.collections.objects.findOne({_id: this.id}, function(err, doc) {
+    if(err) return callback(err);
+    if(doc[prop] === undefined) return callback(new Error('prop does not exist'));
 
-  this._app.collections.objects.updateOne({_id: this.id}, upd, function(err, res) {
-    if(err) return err;
-    if(res.modifiedCount < 1) return callback(new Error('prop does not exist'));
-    callback(null);
-  });
+    this._app.collections.objects.updateOne({_id: this.id}, upd, function(err, res) {
+      if(err) return callback(new Error(err));
+      if(res.modifiedCount < 1) return callback(new Error('prop does not exist'));
+      callback(null);
+    }.bind(this));
+  }.bind(this));
 };
 
 module.exports = MObject;

--- a/lib/mobject.js
+++ b/lib/mobject.js
@@ -53,6 +53,7 @@ MObject.prototype.delVerb = function(verb, callback) {
   this._app.collections.objects.updateOne({_id: this.id}, upd, function(err, res) {
     if(err) return err;
     if(res.modifiedCount < 1) return callback(new Error('verb does not exist'));
+    console.log(res);
     callback(null);
   });
 };

--- a/lib/mobject.js
+++ b/lib/mobject.js
@@ -50,12 +50,16 @@ MObject.prototype.delVerb = function(verb, callback) {
   var upd = {$unset: {}};
   upd.$unset['_verbs.' + verb] = '';
 
-  this._app.collections.objects.updateOne({_id: this.id}, upd, function(err, res) {
-    if(err) return err;
-    if(res.modifiedCount < 1) return callback(new Error('verb does not exist'));
-    console.log(res);
-    callback(null);
-  });
+  this._app.collections.objects.findOne({_id: this.id}, function(err, doc) {
+    if(err) return callback(err);
+    if(doc._verbs[verb] === undefined) return callback(new Error('verb does not exist'));
+
+    this._app.collections.objects.updateOne({_id: this.id}, upd, function(err, res) {
+      if(err) return callback(err);
+      if(res.modifiedCount < 1) return callback(new Error('verb does not exist'));
+      return callback(null);
+    }.bind(this));
+  }.bind(this));
 };
 
 // Create a VM using the verb name specified

--- a/test/mobject.js
+++ b/test/mobject.js
@@ -13,6 +13,9 @@ describe('MObject', function() {
   var app, db, mobj;
 
   beforeEach(function(done) {
+    this.timeout(5000); // Set timeout to 5 seconds, as Travis may take a while
+                        // to get mongo set up.
+
     async.series([
       function(cb) {
         MongoClient.connect('mongodb://127.0.0.1:27017/nickmoo-test', function(err, _db) {


### PR DESCRIPTION
This fixes the issues with Travis CI building.
- Travis is running a different version of Mongo from my development machine, checking if updateOne removed a key from a sub-document/hash is done differently. Both ways are now implemented
- Travis is sometimes too slow and causes mocha to timeout, failing the tests. Timeout has been increased
