### PR TITLE
MObject verbcall: Basic impl for creating VMs from local verbs

### DIFF
--- a/lib/mobject.js
+++ b/lib/mobject.js
@@ -242,4 +242,59 @@ MObject.prototype.resolveChildObj = function(name, callback) {
   });
 }
 
+// Creates a VM from a verbcall object/structure
+MObject.prototype.verbcall = function(verbcallObj, finalCallback) {
+  async.series([
+    function(callback) {
+      // Resolve any object names that are a child of this object.
+      async.each(['directObj', 'indirectObj'], function(objRef, callback) {
+        if(typeof(verbcallObj[objRef]) !== 'string') return callback();
+        this.resolveChildObj(verbcallObj[objRef], function(err, obj) {
+          if(err) return callback(err);
+          if(obj === null) return callback();
+          verbcallObj[objRef] = obj.id;
+          callback();
+        }.bind(this));
+      }.bind(this), callback);
+    }.bind(this),
+
+    function(callback) {
+      // Resolve any object names that are a child of the parent object.
+      this.getParent(function(err, parent) {
+        async.each(['directObj', 'indirectObj'], function(objRef, callback) {
+          if(typeof(verbcallObj[objRef]) !== 'string') return callback();
+          if(err) return callback(err);
+          if(parent === null) return callback();
+          parent.resolveChildObj(verbcallObj[objRef], function(err, obj) {
+            if(err) return callback(err);
+            if(obj === null) return callback();
+            verbcallObj[objRef] = obj.id;
+            callback();
+          }.bind(this));
+        }.bind(this), callback);
+      }.bind(this));
+    }.bind(this),
+
+    function(callback) {
+      // Names have been replaced with object IDs, create a VM
+      // Just handle local verbcalls for now
+      this.vmFromVerb(verbcallObj.verb, function(err, vm) {
+        if(err) {
+          if(err.message === 'verb does not exist') return callback();
+          return callback(err);
+        }
+        for(var k in verbcallObj) {
+          if(k === 'type') continue;
+          vm.state.localVars['_' + k] = verbcallObj[k];
+        }
+        vm.state.localVars._caller = this.id; // Set the caller to us
+        return finalCallback(null, vm);
+      }.bind(this));
+    }.bind(this)
+  ], function(err) {
+    if(err) return callback(err);
+    finalCallback(new Error('verb does not exist'));
+  });
+}
+
 module.exports = MObject;

--- a/test/mobject.js
+++ b/test/mobject.js
@@ -626,15 +626,15 @@ describe('MObject', function() {
       mobj.verbcall(verbcall, function(err, vm) {
         expect(err).to.be.null;
         expect(vm).to.be.an.instanceof(NML.VM);
-        expect(vm.id.toString()).to.equal(mobj.id.toString());
-        expect(vm.state.localVars._caller.toString()).to.equal(mobj.id.toString());
-        expect(vm.state.ast).to.eql([{type: 'verb', src: '$a = 2'}]);
+        expect(vm.mobj.id.toString()).to.equal(mobj.id.toString());
+        expect(vm.state.ast).to.eql([{ type: 'assign', op: '=', src: [ 2 ], dst: { type: 'var', name: 'a' } }]);
         expect(vm.state.localVars).to.eql({
           _verb: 'put',
           _directObj: dirObj,
           _prepos: 'in',
           _indirectObj: indirObj,
-          _params: [dirObj, 'in', indirObj]
+          _params: [dirObj, 'in', indirObj],
+          _caller: mobj.id
         });
         done();
       });
@@ -674,7 +674,7 @@ describe('MObject', function() {
       mobj.verbcall(verbcall, function(err, vm) {
         expect(err).to.be.null;
         expect(vm).to.be.an.instanceof(NML.VM);
-        expect(vm.id.toString()).to.equal(mobj.id.toString());
+        expect(vm.mobj.id.toString()).to.equal(mobj.id.toString());
         expect(vm.state.localVars._caller.toString()).to.equal(mobj.id.toString());
         expect(vm.state.ast).to.eql([{type: 'verb', src: '$a = 1234'}]);
         expect(vm.state.localVars).to.eql({
@@ -704,7 +704,7 @@ describe('MObject', function() {
         expect(err).to.be.null;
         expect(vm).to.be.an.instanceof(NML.VM);
         // The VM is created in the context of the parent object, where the verb exists
-        expect(vm.id.toString()).to.equal(mobj.id.toString());
+        expect(vm.mobj.id.toString()).to.equal(mobj.id.toString());
         expect(vm.state.localVars._caller.toString()).to.equal(childMobj.id.toString());
         expect(vm.state.ast).to.eql([{type: 'verb', src: '$a = 2'}]);
         expect(vm.state.localVars).to.eql({


### PR DESCRIPTION
Basic implementation for creating VMs from local verbs. Passes the first two MObject#verbcall tests.
